### PR TITLE
fix references to various SSIS versions

### DIFF
--- a/docs/integration-services/packages/deploy-integration-services-ssis-projects-and-packages.md
+++ b/docs/integration-services/packages/deploy-integration-services-ssis-projects-and-packages.md
@@ -29,7 +29,7 @@ manager: "jhubbard"
 For more information about the legacy package deployment model, see [Legacy Package Deployment &#40;SSIS&#41;](../../integration-services/packages/legacy-package-deployment-ssis.md).  
   
 > [!NOTE]  
->  The project deployment model was introduced in [!INCLUDE[ssISversion11](../../includes/ssisversion11-md.md)]. If you used this model, you were not able to deploy one or more packages without deploying the whole project. The [!INCLUDE[ssISCurrent](../../includes/ssiscurrent-md.md)] introduced the Incremental Package Deployment feature that allows you to deploy one or more packages without deploying the whole project.  
+>  The project deployment model was introduced in [!INCLUDE[ssISversion11](../../includes/ssisversion11-md.md)]. If you used this model, you were not able to deploy one or more packages without deploying the whole project. The [!INCLUDE[ssISversion13](../../includes/ssISversion13-md.md)] introduced the Incremental Package Deployment feature that allows you to deploy one or more packages without deploying the whole project.  
   
 ## Compare Project Deployment Model and legacy Package Deployment Model  
  The type of deployment model that you choose for a project determines which development and administrative options are available for that project. The following table shows the differences and similarities between using the project deployment model and using the package deployment model.  
@@ -48,7 +48,7 @@ For more information about the legacy package deployment model, see [Legacy Pack
 |Packages are run in a separate Windows process.|Packages are run in a separate Windows process.|  
 |SQL Server Agent is used to schedule package execution.|SQL Server Agent is used to schedule package execution.|  
   
- The project deployment model was introduced in [!INCLUDE[ssISversion11](../../includes/ssisversion11-md.md)]. If you used this model, you were not able to deploy one or more packages without deploying the whole project. The [!INCLUDE[ssISCurrent](../../includes/ssiscurrent-md.md)] introduced the Incremental Package Deployment feature that allows you to deploy one or more packages without deploying the whole project.   
+ The project deployment model was introduced in [!INCLUDE[ssISversion11](../../includes/ssisversion11-md.md)]. If you used this model, you were not able to deploy one or more packages without deploying the whole project. The [!INCLUDE[ssISversion13](../../includes/ssISversion13-md.md)] introduced the Incremental Package Deployment feature that allows you to deploy one or more packages without deploying the whole project.   
   
 ## Features of Project Deployment Model  
  The following table lists the features that are available to projects developed only for the project deployment model.  
@@ -97,7 +97,7 @@ For more info about the error described in this section and about the permission
   
 2.  Convert the project to the project deployment model by running the **Integration Services Project Conversion Wizard** . For more information, see the instructions below: [To convert a project to the project deployment model](#convert)  
   
-    -   If you created the project in [!INCLUDE[ssISCurrent](../../includes/ssiscurrent-md.md)], by default the project uses the project deployment model.  
+    -   If you created the project in [!INCLUDE[ssISversion12](../../includes/ssISversion12-md.md)], by default the project uses the project deployment model.  
   
     -   If you created the project in an earlier release of [!INCLUDE[ssISnoversion](../../includes/ssisnoversion-md.md)], after you open the project file in [!INCLUDE[vsprvs](../../includes/vsprvs-md.md)], convert the project to the project deployment model.  
   
@@ -151,7 +151,7 @@ For more info about the error described in this section and about the permission
 3.  Complete the wizard. 
 
 ## Deploy Packages to Integration Services Server
-  The Incremental Package Deployment feature introduced in  [!INCLUDE[ssISCurrent](../../includes/ssiscurrent-md.md)] lets you deploy one or more packages to an existing or new project without deploying the whole project.  
+  The Incremental Package Deployment feature introduced in  [!INCLUDE[ssISversion13](../../includes/ssISversion13-md.md)] lets you deploy one or more packages to an existing or new project without deploying the whole project.  
   
 ###  <a name="DeployWizard"></a> Deploy packages by using the Integration Services Deployment Wizard  
   


### PR DESCRIPTION
We were using a "Current Version" include when we should have been referencing specific versions of SSIS which caused a ton of confusion when the "Current Version" include was updated to "2017".